### PR TITLE
ci: Enable containerd snapshotter on GitHub Actions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -20,6 +20,12 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: ./bin/make docker-login
+    - name: Enable containerd snapshotter
+      run: |
+        { cat /etc/docker/daemon.json 2>/dev/null || echo '{}'; } | \
+        jq '.features += {"containerd-snapshotter": true}' > /tmp/daemon.json
+        sudo mv /tmp/daemon.json /etc/docker/daemon.json
+        sudo systemctl restart docker
     - name: Build and publish release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Enable the containerd snapshotter on the Docker daemon on the GitHub
Actions runner so we have a multi-architecture image store and so that
`docker buildx` will work. We do cross compiling with Go so we do not
need the qemu thing for running the builder on a foreign architecture.

Test-run: https://github.com/foxygoat/flapjak/actions/runs/19528620262
