### PR TITLE
Make attribute value comparison case-insensitive

### DIFF
--- a/db.go
+++ b/db.go
@@ -158,11 +158,17 @@ func pwCheckSaltedHash(password string, hashtext string, newHash func() hash.Has
 }
 
 // HasValue returns true if val is one of the values of the attribute. The
-// value is compared case-sensitively, regardless of what an LDAP schema
+// value is compared case-insensitively, regardless of what an LDAP schema
 // may say for that attribute.
 func (a Attr) HasValue(val string) bool {
-	// TODO(camh): Handle case-insensitive values
-	return slices.Contains(a.Vals, val)
+	// TODO(camh): Handle case-sensitive values
+	lv := strings.ToLower(val)
+	for _, v := range a.Vals {
+		if strings.ToLower(v) == lv {
+			return true
+		}
+	}
+	return false
 }
 
 // IsSensitive returns true if the attribute is a sensitive one, such as a

--- a/db_test.go
+++ b/db_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"hash"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/matryer/is"
@@ -149,6 +150,7 @@ func Test_Entry_CaseInsensitiveAttrs(t *testing.T) {
 	is.Equal(1, len(a.Vals))
 	is.Equal("sn", a.Name)
 	is.Equal(emap["sn"], a.Vals[0])
+	is.True(a.HasValue(strings.ToUpper(a.Vals[0])))
 
 	a, ok = e.GetAttr("SN")
 	is.True(ok)


### PR DESCRIPTION
When checking if an attribute has a value with `HasValue()`, compare
values case-insensitively. There was a todo for this, which has now
changed to a todo for case-sensitive comparison. This should be
specified in the LDAP schema, but flapjak does not use a schema so this
is what works best. Most attributes in practice that are used for lookup
in a filter will be case-insensitive.
